### PR TITLE
Cooperative gestures - scroll normally, zoom with command key.

### DIFF
--- a/src/Shelters.tsx
+++ b/src/Shelters.tsx
@@ -18,9 +18,9 @@ const Shelters = ({ geoJSON, selectedShelter, onSelect }) => {
         latitude: selectedShelter ? selectedShelter.latitude : 44.38,
         zoom: selectedShelter ? 10 : 4,
       }}
+      cooperativeGestures={true}
       style={{ width: '100vw', height: '100vh' }}
       mapStyle="mapbox://styles/mapbox/streets-v9"
-      scrollZoom={false}
     >
       <FullscreenControl />
       <NavigationControl />

--- a/src/Shelters.tsx
+++ b/src/Shelters.tsx
@@ -20,6 +20,7 @@ const Shelters = ({ geoJSON, selectedShelter, onSelect }) => {
       }}
       style={{ width: '100vw', height: '100vh' }}
       mapStyle="mapbox://styles/mapbox/streets-v9"
+      scrollZoom={false}
     >
       <FullscreenControl />
       <NavigationControl />


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-js/issues/6884#issuecomment-948156016

> If you set the new Map({ cooperativeGestures: true, ... }) then ctrl or ⌘ will be required to scroll. Two touches will be required to pan on mobile to prevent a similar problem there.
